### PR TITLE
Decrease library minSdkVersion from 19 to 14

### DIFF
--- a/circularprogressbar/build.gradle
+++ b/circularprogressbar/build.gradle
@@ -6,7 +6,7 @@ group = 'com.github.brkckr'
 android {
     compileSdkVersion 27
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 14
         targetSdkVersion 27
         versionCode 2
         versionName "1.0.1"


### PR DESCRIPTION
Decrease required minSdkVersion to enable devs who required to support lower versions of android to use the library as none of APIs added with these versions are used.